### PR TITLE
Bar 693 fixed HiveCommandClient to be compatible with Python 3

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+luigi (2.4.2-SWISSCOM) snapshot; urgency=low
+
+  * https://github.com/swisscom-bigdata/luigi/releases/tag/2.4.2-SWISSCOM
+
 luigi (2.4.1-SWISSCOM) snapshot; urgency=low
 
   * See https://github.com/swisscom-bigdata/luigi/releases/tag/2.4.1-SWISSCOM

--- a/luigi/contrib/hive.py
+++ b/luigi/contrib/hive.py
@@ -139,7 +139,7 @@ class HiveCommandClient(HiveClient):
         if partition is None:
             stdout = run_hive_cmd('use {0}; show tables like "{1}";'.format(database, table))
 
-            return stdout and table.lower() in stdout
+            return stdout and table.lower() in str(stdout)
         else:
             stdout = run_hive_cmd("""use %s; show partitions %s partition
                                 (%s)""" % (database, table, self.partition_spec(partition)))

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ if os.environ.get('READTHEDOCS', None) == 'True':
 
 setup(
     name='luigi',
-    version='2.4.1-SWISSCOM',
+    version='2.4.2-SWISSCOM',
     description='Workflow mgmgt + task scheduling + dependency resolution',
     long_description=long_description,
     author='Erik Bernhardsson',


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
fixed HiveCommandClient to be compatible with Python 3

## Have you tested this? If so, how?
Tested on edgenode02, dev environement, HDM application
